### PR TITLE
rename package as it has diverged significantly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "soap",
+  "name": "ifit-soap",
+  "private": true,
   "version": "0.2.6",
   "description": "A minimal node SOAP client",
   "engines": {


### PR DESCRIPTION
This module has fallen far behind the published `soap` module, and has significant enough changes that we should rename it.
